### PR TITLE
fix build error on MacRuby 

### DIFF
--- a/ext/event_dispatcher/extconf.rb
+++ b/ext/event_dispatcher/extconf.rb
@@ -12,6 +12,12 @@ dir_config(extension_name)
 
 $LDFLAGS += ' -framework ApplicationServices'
 
+begin
+  MACRUBY_VERSION # Only MacRuby has this constant.
+  $CFLAGS += ' -fobjc-gc' # Enable MacOSX's GC for MacRuby
+rescue
+end
+
 have_header(extension_name)
 
 # Do the work

--- a/ext/util/extconf.rb
+++ b/ext/util/extconf.rb
@@ -12,6 +12,12 @@ dir_config(extension_name)
 
 $LDFLAGS += ' -framework ApplicationServices -framework AppKit'
 
+begin
+  MACRUBY_VERSION # Only MacRuby has this constant.
+  $CFLAGS += ' -fobjc-gc' # Enable MacOSX's GC for MacRuby
+rescue
+end
+
 have_header(extension_name)
 
 # Do the work


### PR DESCRIPTION
Thank you, awesome gems.

Unfortunately, it seems which this gem can't install on MacRuby.

```
$ sudo macgem install mac-robot  
Fetching: mac-robot-0.2.2.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing mac-robot:
    ERROR: Failed to build gem native extension.

        /Library/Frameworks/MacRuby.framework/Versions/0.13/usr/bin/macruby extconf.rb
checking for event_dispatcher... no
creating Makefile

make
/usr/bin/gcc -fno-common -arch x86_64 -fexceptions -fno-common -pipe -O3 -g -Wall -arch x86_64   -c -o event_dispatcher.o event_dispatcher.m
/usr/bin/gcc -dynamic -bundle -undefined suppress -flat_namespace -arch x86_64 -o event_dispatcher.bundle event_dispatcher.o -L. -L/Library/Frameworks/MacRuby.framework/Versions/0.13/usr/lib -arch x86_64 -framework ApplicationServices   -lmacruby   
ld: Linked dylibs built for GC-only but object files built for retain/release for architecture x86_64
collect2: ld returned 1 exit status
make: *** [event_dispatcher.bundle] Error 1


Gem files will remain installed in /Library/Ruby/Gems/MacRuby/0.13/gems/mac-robot-0.2.2 for inspection.
Results logged to /Library/Ruby/Gems/MacRuby/0.13/gems/mac-robot-0.2.2/ext/event_dispatcher/gem_make.out
```

MacRuby need GC flag for Ruby C extension using Objective-C.
https://github.com/MacRuby/MacRuby/wiki/Loading-Objective-C-Frameworks-and-Bundles

``` ruby
require "mkmf"
$CFLAGS << ' -fobjc-gc '  # use a GC 
```

Cheers
